### PR TITLE
Fixes #6: Update tests to reflect changes to Werkzeug

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,7 +8,7 @@ def test_register(client, app):
     response = client.post(
         '/auth/register', data={'username': 'a', 'displayname' : 'user1' ,'password': 'a'}
     )
-    assert 'http://localhost/auth/login' == response.headers['Location']
+    assert '/auth/login' == response.headers['Location']
 
     with app.app_context():
         assert get_db().execute(
@@ -34,7 +34,7 @@ def test_register_validate_input(client, username, displayname, password, messag
 def test_login(client, auth):
     assert client.get('/auth/login').status_code == 200
     response = auth.login()
-    assert response.headers['Location'] == 'http://localhost/'
+    assert response.headers['Location'] == '/'
 
     with client:
         client.get('/')

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -23,7 +23,7 @@ def test_index(client, auth):
 ))
 def test_login_required(client, path):
     response = client.post(path)
-    assert response.headers['Location'] == 'http://localhost/auth/login'
+    assert response.headers['Location'] == '/auth/login'
 
 
 def test_author_required(app, client, auth):
@@ -84,7 +84,7 @@ def test_create_update_validate(client, auth, path):
 def test_delete(client, auth, app):
     auth.login()
     response = client.post('/1/delete')
-    assert response.headers['Location'] == 'http://localhost/'
+    assert response.headers['Location'] == '/'
 
     with app.app_context():
         db = get_db()


### PR DESCRIPTION
The `Location` field in the Werkzeug response class only contains the relative location in recent versions. The unit tests should reflect this.