### PR TITLE
Fixes #8 Vulnerable to CSRF

### DIFF
--- a/bad_apps_blog/__init__.py
+++ b/bad_apps_blog/__init__.py
@@ -35,6 +35,7 @@ def create_app(test_config=None):
         APP_VERSION = '0.0.1',
         DB_VERSION = '0.0.1',
         DATABASE=os.path.join(app.instance_path, 'bad_apps_blog.sqlite'),
+        CSRF_TOKEN_AGE = 3600 # seconds
     )
 
     if test_config is None:
@@ -44,6 +45,7 @@ def create_app(test_config=None):
     else:
         # load the test config if passed in
         test_config['SECRET_KEY'] = secrets.token_hex(32)
+        test_config['CSRF_TOKEN_AGE'] = 2
         app.config.from_mapping(test_config)
         app.logger.info('generating test configuration')
 

--- a/bad_apps_blog/auth.py
+++ b/bad_apps_blog/auth.py
@@ -183,7 +183,7 @@ def gen_csrf_token():
             db.execute(
                 'UPDATE csrf SET token = ?, expire = ?'
                 'WHERE id = ?',
-                (token, time.time() + 3600.0, user_id)
+                (token, time.time() + current_app.config['CSRF_TOKEN_AGE'], user_id)
             )
             db.commit()
             return token
@@ -194,7 +194,7 @@ def gen_csrf_token():
         db.execute(
             'INSERT INTO csrf (id, token, expire)'
             'VALUES (?, ?, ?)',
-            (user_id, token, time.time() + 3600.0 )
+            (user_id, token, time.time() + current_app.config['CSRF_TOKEN_AGE'] )
         )
         db.commit()
         return token

--- a/bad_apps_blog/auth.py
+++ b/bad_apps_blog/auth.py
@@ -149,9 +149,9 @@ def csrf_proect(view):
                 assert current['expire'] > time.time()
                 current_app.logger.info(f' [SECURITY] CSRF token is unexpired for {user_id}')
                 return view(**kwargs)
-            except:
+            except AssertionError:
                 current_app.logger.error(f' [SECURITY] Possible CSRF attack : CSRF token does not match for user {user_id}')
-                return redirect(url_for('index'))
+                return redirect(url_for('index')), 403
 
         elif request.method == 'GET':
             token = gen_csrf_token()

--- a/bad_apps_blog/auth.py
+++ b/bad_apps_blog/auth.py
@@ -1,5 +1,8 @@
 import logging
 import functools
+import time
+import secrets
+
 
 from flask import (
     Blueprint, flash, g, redirect, render_template, request, session, url_for, current_app
@@ -120,3 +123,81 @@ def login_required(view):
 
     return wrapped_view
 
+
+def csrf_proect(view):
+    '''
+    Wrapper to apply token-based CSRF protection.
+
+    on GET, should get token and render in a hidden field
+    on POST, should check the token
+    '''
+    @functools.wraps(view)
+    def wrapped_view(**kwargs):
+        user_id = session.get('user_id')
+
+        if request.method == 'POST':
+            current = get_db().execute(
+            'SELECT * FROM csrf WHERE id = ?', (user_id,)).fetchone()
+            
+            # check that the token is not None
+            try:
+                # Q: do I need to process the "input" token in any way?
+                # I'm not making a db query based on the token given in the form, 
+                #   if there any validation needed though?
+                assert current['token'] == request.form['form_number']
+                current_app.logger.info(f' [SECURITY] CSRF token match for user {user_id}')
+                assert current['expire'] > time.time()
+                current_app.logger.info(f' [SECURITY] CSRF token is unexpired for {user_id}')
+                return view(**kwargs)
+            except:
+                current_app.logger.error(f' [SECURITY] Possible CSRF attack : CSRF token does not match for user {user_id}')
+                return redirect(url_for('index'))
+
+        elif request.method == 'GET':
+            token = gen_csrf_token()
+            return view(token=token,**kwargs)
+    
+    return wrapped_view
+
+
+def gen_csrf_token():
+    '''
+    Generate and track a CSRF token.
+    '''
+    user_id = session.get('user_id')
+
+    db = get_db()
+    current = db.execute(
+            'SELECT * FROM csrf WHERE id = ?', (user_id,)
+        ).fetchone()
+
+    if current is not None:
+        if current['expire'] > time.time():
+            # reissue current token
+            current_app.logger.info(f' [SECURITY] re-issued non-expired CSRF token to user {user_id}')
+            return current['token']
+        else:
+            # generate / update new token
+            current_app.logger.info(f' [SECURITY] updated expired CSRF token for user {user_id}')
+            token = secrets.token_hex(64)
+            db.execute(
+                'UPDATE csrf SET token = ?, expire = ?'
+                'WHERE id = ?',
+                (token, time.time() + 3600.0, user_id)
+            )
+            db.commit()
+            return token
+    elif current is None:
+        # TODO: use app configuration to set expiration age of CSRF tokens
+        current_app.logger.info(f' [SECURITY] generated new CSRF token for user {user_id}')        
+        token = secrets.token_hex(64)
+        db.execute(
+            'INSERT INTO csrf (id, token, expire)'
+            'VALUES (?, ?, ?)',
+            (user_id, token, time.time() + 3600.0 )
+        )
+        db.commit()
+        return token
+    else:
+        logging.error('Failed to generate CSRF token')
+        return None

--- a/bad_apps_blog/blog.py
+++ b/bad_apps_blog/blog.py
@@ -3,7 +3,7 @@ from flask import (
 )
 from werkzeug.exceptions import abort
 
-from bad_apps_blog.auth import login_required
+from bad_apps_blog.auth import login_required, csrf_proect
 from bad_apps_blog.db import get_db
 
 bp = Blueprint('blog', __name__)
@@ -20,7 +20,8 @@ def index():
 
 @bp.route('/create', methods=('GET', 'POST'))
 @login_required
-def create():
+@csrf_proect
+def create(token=None):
     if request.method == 'POST':
         title = request.form['title']
         body = request.form['body']
@@ -43,7 +44,10 @@ def create():
             current_app.logger.info('new post successfully commited to db')
             return redirect(url_for('blog.index'))
 
-    return render_template('blog/create.html')
+    if token is not None:
+        return render_template('blog/create.html', csrf=token)
+    else:
+        return render_template('blog/create.html')
 
 def get_post(id, check_author=True):
     post = get_db().execute(
@@ -70,7 +74,8 @@ def get_post(id, check_author=True):
 
 @bp.route('/<int:id>/update', methods=('GET', 'POST'))
 @login_required
-def update(id):
+@csrf_proect
+def update(id, token=None):
     post = get_post(id)
 
     if request.method == 'POST':
@@ -95,11 +100,15 @@ def update(id):
             current_app.logger.info(f'post {id} updates successfully commited to db')
             return redirect(url_for('blog.index'))
 
-    return render_template('blog/update.html', post=post)
+    if token is not None:
+        return render_template('blog/update.html', post=post, csrf=token)
+    else:
+        return render_template('blog/update.html', post=post)
 
 
 @bp.route('/<int:id>/delete', methods=('POST',))
 @login_required
+@csrf_proect
 def delete(id):
     get_post(id)
     current_app.logger.warning(f' [SECURITY] post {id} is being deleted')

--- a/bad_apps_blog/gen_config.py
+++ b/bad_apps_blog/gen_config.py
@@ -10,6 +10,7 @@ def init_config():
         current_app.logger.info(f' {__name__} : Configuration is incomplete : generating configuration file in instance folder')
         with open(os.path.join(current_app.instance_path, 'config.py'), 'a') as f:
             f.write('SECRET_KEY="'+secrets.token_hex(32)+'"')
+            f.write("SESSION_COOKIE_SAMESITE='Strict'")
         return "Initialized config.py"
     else:
         current_app.logger.info(f' {__name__} : Configuration is complete : no action necessary')

--- a/bad_apps_blog/schema.sql
+++ b/bad_apps_blog/schema.sql
@@ -23,3 +23,9 @@ CREATE TABLE post (
   body TEXT NOT NULL,
   FOREIGN KEY (author_id) REFERENCES user (id)
 );
+
+CREATE_TABLE csrf (
+  id INTEGER UNIQUE PRIMARY KEY,
+  token TEXT UNIQUE NOT NULL,
+  expire INTEGER NOT NULL
+);

--- a/bad_apps_blog/schema.sql
+++ b/bad_apps_blog/schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE post (
   FOREIGN KEY (author_id) REFERENCES user (id)
 );
 
-CREATE_TABLE csrf (
+CREATE TABLE csrf (
   id INTEGER UNIQUE PRIMARY KEY,
   token TEXT UNIQUE NOT NULL,
   expire INTEGER NOT NULL

--- a/bad_apps_blog/templates/blog/create.html
+++ b/bad_apps_blog/templates/blog/create.html
@@ -12,8 +12,6 @@
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     {% if csrf is defined %}
       <input type="hidden" name="form_number" value="{{ csrf }}">
-    {% else -%}
-      <input type="hidden" name="form_number" value="">
     {% endif %}
     <input type="submit" value="Save">
   </form>

--- a/bad_apps_blog/templates/blog/create.html
+++ b/bad_apps_blog/templates/blog/create.html
@@ -10,6 +10,11 @@
     <input name="title" id="title" value="{{ request.form['title'] }}" required>
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
+    {% if csrf is defined %}
+      <input class="hidden" name="form_number" value="{{ request.form['form_number'] or csrf }}">
+    {% else -%}
+      <input class="hidden" name="form_number" value="">
+    {% endif %}
     <input type="submit" value="Save">
   </form>
 {% endblock %}

--- a/bad_apps_blog/templates/blog/create.html
+++ b/bad_apps_blog/templates/blog/create.html
@@ -11,9 +11,9 @@
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] }}</textarea>
     {% if csrf is defined %}
-      <input class="hidden" name="form_number" value="{{ request.form['form_number'] or csrf }}">
+      <input type="hidden" name="form_number" value="{{ csrf }}">
     {% else -%}
-      <input class="hidden" name="form_number" value="">
+      <input type="hidden" name="form_number" value="">
     {% endif %}
     <input type="submit" value="Save">
   </form>

--- a/bad_apps_blog/templates/blog/update.html
+++ b/bad_apps_blog/templates/blog/update.html
@@ -14,17 +14,13 @@
     <input type="submit" value="Save">
    {% if csrf is defined %}
      <input type="hidden" name="form_number" value="{{ csrf }}">
-     {% else -%}
-     <input type="hidden" name="form_number" value="">
    {% endif %}
   </form>
   <hr>
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
     {% if csrf is defined %}
-    <input type="hidden" name="form_number" value="{{ csrf }}">
-      {% else -%}
-    <input type="hidden" name="form_number" value="">
+      <input type="hidden" name="form_number" value="{{ csrf }}">
     {% endif %}
   </form>
 {% endblock %}

--- a/bad_apps_blog/templates/blog/update.html
+++ b/bad_apps_blog/templates/blog/update.html
@@ -12,6 +12,11 @@
     <label for="body">Body</label>
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">
+   {% if csrf is defined %}
+     <input class="hidden" name="form_number" value="{{ request.form['form_number'] or csrf }}">
+     {% else -%}
+     <input class="hidden" name="form_number" value="">
+   {% endif %}
   </form>
   <hr>
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">

--- a/bad_apps_blog/templates/blog/update.html
+++ b/bad_apps_blog/templates/blog/update.html
@@ -13,13 +13,18 @@
     <textarea name="body" id="body">{{ request.form['body'] or post['body'] }}</textarea>
     <input type="submit" value="Save">
    {% if csrf is defined %}
-     <input class="hidden" name="form_number" value="{{ request.form['form_number'] or csrf }}">
+     <input type="hidden" name="form_number" value="{{ csrf }}">
      {% else -%}
-     <input class="hidden" name="form_number" value="">
+     <input type="hidden" name="form_number" value="">
    {% endif %}
   </form>
   <hr>
   <form action="{{ url_for('blog.delete', id=post['id']) }}" method="post">
     <input class="danger" type="submit" value="Delete" onclick="return confirm('Are you sure?');">
+    {% if csrf is defined %}
+    <input type="hidden" name="form_number" value="{{ csrf }}">
+      {% else -%}
+    <input type="hidden" name="form_number" value="">
+    {% endif %}
   </form>
 {% endblock %}

--- a/tests/data.sql
+++ b/tests/data.sql
@@ -7,4 +7,7 @@ INSERT INTO post (title, body, author_id, created)
 VALUES
   ('test title', 'test' || x'0a' || 'body', 1, '2018-01-01 00:00:00');
 
+INSERT INTO csrf (id, token, expire)
+VALUES
+  ('1', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa','33186717886');
 

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -40,7 +40,6 @@ def test_author_required(app, client, auth):
     # current user doesn't see edit link
     assert b'href="/1/update"' not in client.get('/').data
 
-# use CSRF fixture to get token / include it in the POST request
 @pytest.mark.parametrize('path', (
     '/2/update',
     '/2/delete',

--- a/tests/test_blog.py
+++ b/tests/test_blog.py
@@ -35,27 +35,27 @@ def test_author_required(app, client, auth):
 
     auth.login()
     # current user can't modify other user's post
-    assert client.post('/1/update').status_code == 403
-    assert client.post('/1/delete').status_code == 403
+    assert client.post('/1/update', data={'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}).status_code == 403
+    assert client.post('/1/delete', data={'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}).status_code == 403
     # current user doesn't see edit link
     assert b'href="/1/update"' not in client.get('/').data
 
-
+# use CSRF fixture to get token / include it in the POST request
 @pytest.mark.parametrize('path', (
     '/2/update',
     '/2/delete',
 ))
 def test_exists_required(client, auth, path):
     auth.login()
-    assert client.post(path).status_code == 404
+    assert client.post(path, data={'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}).status_code == 404
 
 
 def test_create(client, auth, app):
     auth.login()
-    assert client.get('/create').status_code == 200
-    client.post('/create', data={'title': 'created', 'body': ''})
+    assert client.get('/create', follow_redirects=True).status_code == 200
+    client.post('/create', data={'title': 'created', 'body': '', 'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'})
 
-    with app.app_context():
+    with app.app_context():   
         db = get_db()
         count = db.execute('SELECT COUNT(id) FROM post').fetchone()[0]
         assert count == 2
@@ -64,7 +64,7 @@ def test_create(client, auth, app):
 def test_update(client, auth, app):
     auth.login()
     assert client.get('/1/update').status_code == 200
-    client.post('/1/update', data={'title': 'updated', 'body': ''})
+    client.post('/1/update', data={'title': 'updated', 'body': '', 'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'})
 
     with app.app_context():
         db = get_db()
@@ -78,12 +78,12 @@ def test_update(client, auth, app):
 ))
 def test_create_update_validate(client, auth, path):
     auth.login()
-    response = client.post(path, data={'title': '', 'body': ''})
+    response = client.post(path, data={'title': '', 'body': '', 'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'})
     assert b'Title is required.' in response.data
 
 def test_delete(client, auth, app):
     auth.login()
-    response = client.post('/1/delete')
+    response = client.post('/1/delete', data={'form_number' : 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'})
     assert response.headers['Location'] == '/'
 
     with app.app_context():

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,22 @@
+import pytest
+from bad_apps_blog.db import get_db
+
+def test_csrf_attack(client, auth, app, caplog):
+    # log our test user in
+    auth.login()
+    # test user triggers the following payloads on the web.
+    assert client.post('/create', data={'title' : 'CSRF ATTACK!' , 'body' : 'This user was sea surfed', 'form_number' : 'abababababab'}).status_code == 403
+    assert "Possible CSRF attack" in caplog.text
+
+    # check that no post was added to the db!
+    with app.app_context():   
+        db = get_db()
+        count = db.execute('SELECT COUNT(id) FROM post').fetchone()[0]
+        assert count == 1
+
+    assert client.post('/1/update', data={'title' : 'CSRF ATTACK!', 'body' : 'This user was sea surfed',  'form_number' : 'abababababab'}).status_code == 403
+    assert "Possible CSRF attack" in caplog.text
+
+    assert client.post('/1/delete', data = { 'form_number' : 'abababababab'}).status_code == 403
+    assert "Possible CSRF attack" in caplog.text
+


### PR DESCRIPTION
Added two layers of defense against CSRF attacks.

1. (primary defense) pass an anti-CSRF token to the user which must be returned with all POST forms in order for the transaction to be accepted.
2. (secondary defense) set the `SameSite: Strict` cookie flag at the application level

Additionally, all POST requests against the application which do not include the necessary token are logged as possible CSRF attacks.